### PR TITLE
Fix Permission denied error in ConformerEnsemble.prune_rmsd()

### DIFF
--- a/morfeus/conformer.py
+++ b/morfeus/conformer.py
@@ -1295,6 +1295,7 @@ class ConformerEnsemble:
         """
         with tempfile.NamedTemporaryFile(suffix=".xyz") as ref_file:
             p_ref = Path(ref_file.name)
+            p_ref.unlink()
             self.write_xyz(p_ref, unit="hartree", relative=False)
             process = subprocess.run(
                 f"obrms {p_ref.as_posix()} --cross " "--minimize".split(" "),
@@ -1329,7 +1330,9 @@ class ConformerEnsemble:
                 suffix=".xyz"
             ) as ref_file, tempfile.NamedTemporaryFile(suffix=".xyz") as test_file:
                 p_ref = Path(ref_file.name)
+                p_ref.unlink()
                 p_test = Path(test_file.name)
+                p_test.unlink()
                 self.write_xyz(p_ref, ids=j_s)
                 self.write_xyz(p_test, ids=[i])
                 process = subprocess.run(


### PR DESCRIPTION
This fixes https://github.com/digital-chemistry-laboratory/morfeus/issues/66. We noticed that on Windows-based systems the prune_rmsd() function will give permission errors if the openbabel-based pruning methods are used. This is fixed by unlinking the file after creating it such that the write_xyz function works.