### PR TITLE
Switch from pkg_resources to packaging for parsing versions

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -23,5 +23,4 @@ dependencies:
   - sphinx-copybutton
   - sphinx-inline-tabs
   - sphinxcontrib-bibtex
-  - types-pkg_resources
   - types-setuptools

--- a/environment.yml
+++ b/environment.yml
@@ -3,5 +3,6 @@ channels:
 dependencies:
   - fire
   - numpy
+  - packaging
   - python>=3.8
   - scipy

--- a/morfeus/conformer.py
+++ b/morfeus/conformer.py
@@ -16,7 +16,7 @@ from typing import Any, cast, Type, TypeVar
 import warnings
 
 import numpy as np
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from morfeus.data import (
     HARTREE,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,5 +19,4 @@ sphinx
 sphinx-copybutton
 sphinx-inline-tabs
 sphinxcontrib-bibtex
-types-pkg_resources
 types-setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
+packaging
 scipy
 fire

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     packages=["morfeus"],
     package_data={"morfeus": ["py.typed"]},
     python_requires=">=3.8",
-    install_requires=["fire", "numpy", "scipy"],
+    install_requires=["fire", "numpy", "packaging", "scipy"],
     license="MIT",
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Even after https://github.com/conda-forge/morfeus-ml-feedstock/pull/7 I was still getting a CI failure and realized I've seen this problem before.  See https://github.com/mu-editor/mu/issues/2485 for a summary.  It seems like adding `setuptools` to the recipe should have worked, but it is simply safer to switch to `packaging`.  I think it has something to do with `setuptools` only being present in the build phase, not the run phase, but if you're just doing things locally in a venv, `setuptools` will still be present.

It makes more sense to me to add `packaging` as a runtime dependency than `setuptools`.  After this, there would need to be a new release and the feedstock updated for both the new version and runtime dependency.